### PR TITLE
Fix syntax error in core/helpers/dict.py

### DIFF
--- a/src/sqlfluff/core/helpers/dict.py
+++ b/src/sqlfluff/core/helpers/dict.py
@@ -79,7 +79,7 @@ def nested_combine(*dicts: NestedStringDict[T]) -> NestedStringDict[T]:
 def dict_diff(
     left: NestedStringDict[T],
     right: NestedStringDict[T],
-    ignore: Optional[list[st] = None,
+    ignore: Optional[list[str]] = None,
 ) -> NestedStringDict[T]:
     """Work out the difference between two dictionaries.
 


### PR DESCRIPTION
This PR fixes a syntax error in the `sqlfluff/core/helpers/dict.py` file that was causing the CI build to fail.

The issue was a type annotation error in the `dict_diff` function's `ignore` parameter. The parameter was incorrectly typed as `Optional[list[st]` which had two problems:

1. It used `st` instead of `str` as the type parameter (undefined type)
2. It was missing a closing square bracket `]`

The fix changes it to the correct `Optional[list[str]]` syntax.