### PR TITLE
Fix syntax errors in dialect methods

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -107,7 +107,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[str], self._sets[label]
+        return cast(set[str], self._sets[label])
 
     def bracket_sets(self, label: str) -> set[BracketPairTuple]:
         """Allows access to bracket sets belonging to this dialect."""
@@ -118,7 +118,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple],
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str


### PR DESCRIPTION
This PR fixes syntax errors in the `sets()` and `bracket_sets()` methods in the `sqlfluff/core/dialects/base.py` file.

## Fixes
1. Added missing closing parenthesis in `sets()` method
2. Added missing closing parenthesis and completed the argument in `bracket_sets()` method

These errors were causing the mypy and mypyc tests to fail with 'invalid syntax' errors, preventing proper type checking and compilation.