### PR TITLE
Fix syntax error in dict.py to resolve mypy and mypyc build failures

### DIFF
--- a/src/sqlfluff/core/helpers/dict.py
+++ b/src/sqlfluff/core/helpers/dict.py
@@ -79,7 +79,7 @@ def nested_combine(*dicts: NestedStringDict[T]) -> NestedStringDict[T]:
 def dict_diff(
     left: NestedStringDict[T],
     right: NestedStringDict[T],
-    ignore: Optional[list[st] = None,
+    ignore: Optional[list[str]] = None
 ) -> NestedStringDict[T]:
     """Work out the difference between two dictionaries.
 


### PR DESCRIPTION
This PR fixes syntax errors causing the mypy and mypyc build steps to fail in the CI workflow.

The issue was in `src/sqlfluff/core/helpers/dict.py` where:
1. There was a typo in the type annotation: `list[st]` should be `list[str]`
2. There was an extra comma at the end of the parameter definition

These issues prevented mypy from properly parsing the file, which resulted in the CI build failures.