### PR TITLE
Fix syntax errors in dialect base.py

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -107,7 +107,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[str], self._sets[label]
+        return cast(set[str], self._sets[label])
 
     def bracket_sets(self, label: str) -> set[BracketPairTuple]:
         """Allows access to bracket sets belonging to this dialect."""
@@ -118,7 +118,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple],
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str


### PR DESCRIPTION
Fixed syntax errors in dialect base.py that were causing build failures:

1. Fixed the `Dialect.sets()` method by adding a missing closing parenthesis to the return statement
2. Fixed the `Dialect.bracket_sets()` method by completing the return statement with the missing parameter and closing parenthesis

These syntax errors prevented the code from being properly parsed by the Python interpreter and mypy, causing the CI build to fail.