### PR TITLE
Fix syntax errors in base.py - adding missing closing parentheses

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -107,7 +107,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[str], self._sets[label]
+        return cast(set[str], self._sets[label])
 
     def bracket_sets(self, label: str) -> set[BracketPairTuple]:
         """Allows access to bracket sets belonging to this dialect."""
@@ -118,7 +118,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple],
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str


### PR DESCRIPTION
This PR fixes syntax errors in the SQLFluff project by adding missing closing parentheses and completing incomplete return statements in the `base.py` file.

### Fixes:

1. Fixed the `sets` method by adding a missing closing parenthesis:
   ```python
   return cast(set[str], self._sets[label])
   ```

2. Fixed the `bracket_sets` method by completing the return statement with the missing parameter and closing parenthesis:
   ```python
   return cast(set[BracketPairTuple], self._sets[label])
   ```

These syntax errors were preventing the mypy and mypyc type checking from completing successfully, causing the CI workflow to fail.