### PR TITLE
Fix syntax errors in base.py and dict.py

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -107,7 +107,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[str], self._sets[label]
+        return cast(set[str], self._sets[label])
 
     def bracket_sets(self, label: str) -> set[BracketPairTuple]:
         """Allows access to bracket sets belonging to this dialect."""
@@ -118,7 +118,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple],
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str

--- a/src/sqlfluff/core/helpers/dict.py
+++ b/src/sqlfluff/core/helpers/dict.py
@@ -79,7 +79,7 @@ def nested_combine(*dicts: NestedStringDict[T]) -> NestedStringDict[T]:
 def dict_diff(
     left: NestedStringDict[T],
     right: NestedStringDict[T],
-    ignore: Optional[list[st] = None,
+    ignore: Optional[list[str]] = None,
 ) -> NestedStringDict[T]:
     """Work out the difference between two dictionaries.
 


### PR DESCRIPTION
This PR fixes multiple syntax errors in the SQLFluff project:

### 1. Fixed missing closing parentheses in `base.py`:
   - In the `sets` method:
     ```python
     return cast(set[str], self._sets[label])  # Added missing )
     ```

   - In the `bracket_sets` method:
     ```python
     return cast(set[BracketPairTuple], self._sets[label])  # Added missing ) and parameter
     ```

### 2. Fixed type annotation in `dict.py`:
   - In the `dict_diff` function:
     ```python
     ignore: Optional[list[str]] = None,  # Changed 'st' to 'str'
     ```

These syntax errors were preventing the mypy and mypyc type checking from completing successfully, causing the CI workflow to fail.