### PR TITLE
Fix syntax error in dict.py - mypy type checking failure

### DIFF
--- a/src/sqlfluff/core/helpers/dict.py
+++ b/src/sqlfluff/core/helpers/dict.py
@@ -79,7 +79,7 @@ def nested_combine(*dicts: NestedStringDict[T]) -> NestedStringDict[T]:
 def dict_diff(
     left: NestedStringDict[T],
     right: NestedStringDict[T],
-    ignore: Optional[list[st] = None,
+    ignore: Optional[list[str]] = None,
 ) -> NestedStringDict[T]:
     """Work out the difference between two dictionaries.
 


### PR DESCRIPTION
## Description

This PR fixes a syntax error in the `dict_diff` function parameter declaration in `dict.py`. The error was causing mypy and mypyc type checking to fail in the CI build.

## Issue

The original code had multiple syntax issues:
1. `st` was used but not defined (should be `str`)
2. The parameter default value assignment used `=` inside square brackets instead of after them
3. The closing square bracket was missing before the equals sign
4. There was a comma after the default value inside the parameter declaration

## Fix

The PR correctly formats the type annotation for the `ignore` parameter:
- Fixed the type from `st` to `str`
- Properly closed the square brackets for the type annotation
- Placed the default value assignment outside the type annotation

This change allows mypy and mypyc to run successfully.