### PR TITLE
Fix forward references in base.py type annotations

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -215,8 +215,8 @@ class Dialect:
                 assert isinstance(
                     replacement, type
                 ), f"Cannot replace {n!r} with {replacement}"
-                old_seg = cast(type["BaseSegment"], self._library[n])
-                new_seg = cast(type["BaseSegment"], replacement)
+                old_seg = cast("type[BaseSegment]", self._library[n])
+                new_seg = cast("type[BaseSegment]", replacement)
                 assert issubclass(old_seg, BaseSegment)
                 assert issubclass(new_seg, BaseSegment)
                 subclass = issubclass(new_seg, old_seg)
@@ -264,7 +264,7 @@ class Dialect:
             )
         return grammar
 
-    def get_segment(self, name: str) -> type["BaseSegment"]:
+    def get_segment(self, name: str) -> "type[BaseSegment]":
         """Allow access to segments pre-expansion.
 
         This is typically for dialect inheritance. This method
@@ -272,7 +272,7 @@ class Dialect:
         """
         if name not in self._library:  # pragma: no cover
             raise ValueError(f"Element {name} not found in dialect.")
-        segment = cast(type["BaseSegment"], self._library[name])
+        segment = cast("type[BaseSegment]", self._library[name])
 
         if issubclass(segment, BaseSegment):
             return segment


### PR DESCRIPTION
## Description

This PR fixes the syntax errors in forward references in `base.py` that were causing mypy type checking to fail in the CI build.

## Issue

The code was using incorrect syntax for forward references in type annotations:

```python
# Incorrect syntax for Python 3.10
old_seg = cast(type["BaseSegment"], self._library[n])
```

The correct syntax for forward references in Python 3.10 is to quote the entire expression:

```python
# Correct syntax
old_seg = cast("type[BaseSegment]", self._library[n])
```

## Changes

Fixed all instances of forward references in `base.py` to use the correct syntax that works in Python 3.10:

1. Changed `cast(type["BaseSegment"], self._library[n])` to `cast("type[BaseSegment]", self._library[n])`
2. Changed `cast(type["BaseSegment"], replacement)` to `cast("type[BaseSegment]", replacement)`
3. Changed `def get_segment(self, name: str) -> type["BaseSegment"]:` to `def get_segment(self, name: str) -> "type[BaseSegment]":`
4. Changed `segment = cast(type["BaseSegment"], self._library[name])` to `segment = cast("type[BaseSegment]", self._library[name])`

This change makes the code compatible with Python 3.10's type checking system.