### PR TITLE
Fix syntax errors in dialect base.py causing mypy and mypyc failures

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -107,7 +107,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[str], self._sets[label]
+        return cast(set[str], self._sets[label])
 
     def bracket_sets(self, label: str) -> set[BracketPairTuple]:
         """Allows access to bracket sets belonging to this dialect."""
@@ -118,7 +118,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple],
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str


### PR DESCRIPTION
## Description
This PR fixes syntax errors in the SQLFluff core dialect module by adding missing closing parentheses and completing incomplete return statements in two methods of the `Dialect` class.

## Fixes
Fixed two syntax errors:
1. In the `sets()` method (line 112): Added the missing closing parenthesis to complete the return statement
2. In the `bracket_sets()` method (line 120): Completed the incomplete return statement by adding the missing reference and closing parenthesis

These syntax errors were causing mypy and mypyc checks to fail in the CI workflow.