### PR TITLE
Fix syntax errors in SQLFluff dialect base.py file

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -107,7 +107,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[str], self._sets[label]
+        return cast(set[str], self._sets[label])
 
     def bracket_sets(self, label: str) -> set[BracketPairTuple]:
         """Allows access to bracket sets belonging to this dialect."""
@@ -118,7 +118,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple],
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str


### PR DESCRIPTION
Fixed syntax errors in the SQLFluff dialect base.py file by adding missing closing parentheses and completing the return statements in both the `sets()` and `bracket_sets()` methods, which resolves the build failure in the mypy and mypyc type checking tools.

The build was failing due to two syntax errors:

1. In the `sets()` method (line 110), the return statement was missing a closing parenthesis.
2. In the `bracket_sets()` method (line 121), the return statement was incomplete, missing both the object parameter (`self._sets[label]`) and the closing parenthesis.

These syntax errors prevented the Python code from compiling correctly, which caused the mypy and mypyc type checking tools to fail during the build process.