### PR TITLE
Fix type annotation syntax error in dict_diff function

### DIFF
--- a/src/sqlfluff/core/helpers/dict.py
+++ b/src/sqlfluff/core/helpers/dict.py
@@ -79,7 +79,7 @@ def nested_combine(*dicts: NestedStringDict[T]) -> NestedStringDict[T]:
 def dict_diff(
     left: NestedStringDict[T],
     right: NestedStringDict[T],
-    ignore: Optional[list[st] = None,
+    ignore: Optional[list[str]] = None,
 ) -> NestedStringDict[T]:
     """Work out the difference between two dictionaries.
 


### PR DESCRIPTION
## Description
This PR fixes a syntax error in the type annotation of the `dict_diff` function parameter in `dict.py`.

### Issue
The error involved multiple syntax problems in the type annotation for the `ignore` parameter:
1. A typo in the type annotation: `st` is used instead of `str` (the Python string type)
2. A syntax issue with the type annotation structure: the closing bracket `]` for `Optional[list[st]]` was missing
3. Incorrect placement of the default value `= None` - it should be outside the type annotation

### Fix
Changed `ignore: Optional[list[st] = None,` to `ignore: Optional[list[str]] = None,`

This fix ensures the codebase passes mypy type checking and can be compiled with mypyc.