### PR TITLE
Fix syntax error: Add missing parenthesis in sets method

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -107,7 +107,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[str], self._sets[label]
+        return cast(set[str], self._sets[label])
 
     def bracket_sets(self, label: str) -> set[BracketPairTuple]:
         """Allows access to bracket sets belonging to this dialect."""


### PR DESCRIPTION
## Description
This PR fixes a syntax error in the `sets` method in `base.py` file. The method was missing a closing parenthesis at the end of the return statement.

## Issue
The CI build was failing with a syntax error in mypy and mypyc checks. The error message was:
```
sqlfluff/core/dialects/base.py:112: error: invalid syntax [syntax]
```

## Fix
Added the missing closing parenthesis at the end of the `return cast(set[str], self._sets[label])` statement.

## Testing
Fixed code should pass the mypy and mypyc checks in the CI workflow.