### PR TITLE
Fix syntax error in base.py - missing closing parenthesis

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -107,7 +107,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[str], self._sets[label]
+        return cast(set[str], self._sets[label])
 
     def bracket_sets(self, label: str) -> set[BracketPairTuple]:
         """Allows access to bracket sets belonging to this dialect."""


### PR DESCRIPTION
This PR fixes a syntax error in the `sets` method in `src/sqlfluff/core/dialects/base.py`. 

The error was a missing closing parenthesis on line 110, which was causing both `mypy` and `mypyc` builds to fail with syntax errors.

### Error from CI logs:
```
mypy: commands[0]> mypy -p sqlfluff
.tox/mypy/lib/python3.10/site-packages/sqlfluff/core/dialects/base.py:112: error: invalid syntax  [syntax]
Found 1 error in 1 file (errors prevented further checking)
```

### Fix:
Added the missing closing parenthesis to complete the return statement:
```python
return cast(set[str], self._sets[label])  # Corrected with closing parenthesis
```