### PR TITLE
Fix syntax error in bracket_sets method of Dialect class

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -118,7 +118,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple],
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str


### PR DESCRIPTION
## Description
Fixed an incomplete function call in the SQLFluff dialect system that was causing the CI build to fail. 

## Issue
The `bracket_sets` method in the `Dialect` class had an incomplete `cast()` function call:
- The `cast()` function was missing its second argument (the expression to be cast)
- The closing parenthesis was missing
- This syntax error was preventing the mypy and mypyc checks from completing

## Fix
- Added the missing second argument `self._sets[label]` to the `cast()` function call
- Added the closing parenthesis to complete the expression
- The updated line now correctly returns the casted value

## Testing
This fix should resolve the CI build errors related to mypy type checking.