### PR TITLE
Fix syntax errors in base.py: add missing closing parentheses

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -107,7 +107,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[str], self._sets[label]
+        return cast(set[str], self._sets[label])
 
     def bracket_sets(self, label: str) -> set[BracketPairTuple]:
         """Allows access to bracket sets belonging to this dialect."""
@@ -118,7 +118,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple],
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str


### PR DESCRIPTION
This PR fixes syntax errors in the `Dialect` class in `base.py`:

1. Fixed the `sets()` method at line 112, adding the missing closing parenthesis to complete the `cast` function call:
```python
return cast(set[str], self._sets[label])  # Added closing parenthesis
```

2. Fixed the `bracket_sets()` method at line 123, adding the missing value and closing parenthesis:
```python
return cast(set[BracketPairTuple], self._sets[label])  # Added value and closing parenthesis
```

These syntax errors were causing the mypy and mypyc tests to fail in the CI build.