### PR TITLE
Fix missing closing parentheses in dialects base.py

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -107,7 +107,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[str], self._sets[label]
+        return cast(set[str], self._sets[label])
 
     def bracket_sets(self, label: str) -> set[BracketPairTuple]:
         """Allows access to bracket sets belonging to this dialect."""
@@ -118,7 +118,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple],
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str


### PR DESCRIPTION
This PR fixes the syntax errors in the base.py file that were causing mypy and mypyc checks to fail.

The errors were caused by missing closing parentheses in the `sets()` and `bracket_sets()` methods in the dialects base module. 

Specifically:
1. Added missing closing parenthesis in the `sets()` method
2. Added missing closing parenthesis in the `bracket_sets()` method and also completed the missing code by adding `self._sets[label]` argument

These fixes allow the mypy and mypyc tests to run successfully.