### PR TITLE
Fix syntax errors in dialect base.py

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -107,7 +107,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[str], self._sets[label]
+        return cast(set[str], self._sets[label])
 
     def bracket_sets(self, label: str) -> set[BracketPairTuple]:
         """Allows access to bracket sets belonging to this dialect."""
@@ -118,7 +118,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple],
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str


### PR DESCRIPTION
## Fix syntax errors in sqlfluff dialects base.py

This PR fixes two critical syntax errors in `sqlfluff/core/dialects/base.py` that were causing mypy and mypyc build failures:

1. In the `sets` method at line 112, added the missing closing parenthesis:
```python
return cast(set[str], self._sets[label])
```

2. In the `bracket_sets` method, completed the incomplete return statement:
```python
return cast(set[BracketPairTuple], self._sets[label])
```

These fixes resolve the build failures in the CI pipeline.