### PR TITLE
Fix syntax errors in dialect base.py

### DIFF
--- a/src/sqlfluff/core/dialects/base.py
+++ b/src/sqlfluff/core/dialects/base.py
@@ -107,7 +107,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[str], self._sets[label]
+        return cast(set[str], self._sets[label])
 
     def bracket_sets(self, label: str) -> set[BracketPairTuple]:
         """Allows access to bracket sets belonging to this dialect."""
@@ -118,7 +118,7 @@ class Dialect:
 
         if label not in self._sets:
             self._sets[label] = set()
-        return cast(set[BracketPairTuple],
+        return cast(set[BracketPairTuple], self._sets[label])
 
     def update_keywords_set_from_multiline_string(
         self, set_label: str, values: str

--- a/src/sqlfluff/core/dialects/base.py.bak
+++ b/src/sqlfluff/core/dialects/base.py.bak
@@ -1,0 +1,397 @@
+"""Defines the base dialect class."""
+
+import sys
+from typing import Any, Optional, Union, cast
+
+from sqlfluff.core.parser import (
+    BaseSegment,
+    KeywordSegment,
+    SegmentGenerator,
+    StringParser,
+)
+from sqlfluff.core.parser.grammar.base import BaseGrammar, Nothing
+from sqlfluff.core.parser.lexer import LexerType
+from sqlfluff.core.parser.matchable import Matchable
+from sqlfluff.core.parser.types import BracketPairTuple, DialectElementType
+
+
+class Dialect:
+    """Serves as the basis for runtime resolution of Grammar.
+
+    Args:
+        name (:obj:`str`): The name of the dialect, used for lookup.
+        lexer_matchers (iterable of :obj:`StringLexer`): A structure defining
+            the lexing config for this dialect.
+
+    """
+
+    def __init__(
+        self,
+        name: str,
+        root_segment_name: str,
+        lexer_matchers: Optional[list[LexerType]] = None,
+        library: Optional[dict[str, DialectElementType]] = None,
+        sets: Optional[dict[str, set[Union[str, BracketPairTuple]]]] = None,
+        inherits_from: Optional[str] = None,
+        formatted_name: Optional[str] = None,
+        docstring: Optional[str] = None,
+    ) -> None:
+        self._library = library or {}
+        self.name = name
+        self.lexer_matchers = lexer_matchers
+        self.expanded = False
+        self._sets = sets or {}
+        self.inherits_from = inherits_from
+        self.root_segment_name = root_segment_name
+        # Attributes for documentation
+        self.formatted_name: str = formatted_name or name
+        self.docstring = docstring or f"The dialect for {self.formatted_name}."
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<Dialect: {self.name}>"
+
+    def expand(self) -> "Dialect":
+        """Expand any callable references to concrete ones.
+
+        This must be called before using the dialect. But
+        allows more flexible definitions to happen at runtime.
+
+        NOTE: This method returns a copy of the current dialect
+        so that we don't pollute the original dialect and get
+        dependency issues.
+
+
+        Returns:
+            :obj:`Dialect`: a copy of the given dialect but
+                with expanded references.
+        """
+        # Are we already expanded?
+        if self.expanded:  # pragma: no cover
+            raise ValueError("Attempted to re-expand an already expanded dialect.")
+
+        expanded_copy = self.copy_as(name=self.name)
+        # Expand any callable elements of the dialect.
+        for key in expanded_copy._library:
+            seg_gen = expanded_copy._library[key]
+            if isinstance(seg_gen, SegmentGenerator):
+                # If the element is callable, call it passing the current
+                # dialect and store the result in its place.
+                # Use the .replace() method for its error handling.
+                expanded_copy.replace(**{key: seg_gen.expand(expanded_copy)})
+        # Expand any keyword sets.
+        for keyword_set in [
+            "unreserved_keywords",
+            "reserved_keywords",
+        ]:  # e.g. reserved_keywords, (JOIN, ...)
+            # Make sure the values are available as KeywordSegments
+            keyword_sets = expanded_copy.sets(keyword_set)
+            for kw in keyword_sets:
+                n = kw.capitalize() + "KeywordSegment"
+                if n not in expanded_copy._library:
+                    expanded_copy._library[n] = StringParser(kw.lower(), KeywordSegment)
+        expanded_copy.expanded = True
+        return expanded_copy
+
+    def sets(self, label: str) -> set[str]:
+        """Allows access to sets belonging to this dialect.
+
+        These sets belong to the dialect and are copied for sub
+        dialects. These are used in combination with late-bound
+        dialect objects to create some of the bulk-produced rules.
+
+        """
+        assert label not in (
+            "bracket_pairs",
+            "angle_bracket_pairs",
+        ), f"Use `bracket_sets` to retrieve {label} set."
+
+        if label not in self._sets:
+            self._sets[label] = set()
+        return cast(set[str], self._sets[label])
+
+    def bracket_sets(self, label: str) -> set[BracketPairTuple]:
+        """Allows access to bracket sets belonging to this dialect."""
+        assert label in (
+            "bracket_pairs",
+            "angle_bracket_pairs",
+        ), "Invalid bracket set. Consider using `sets` instead."
+
+        if label not in self._sets:
+            self._sets[label] = set()
+        return cast(set[BracketPairTuple],
+
+    def update_keywords_set_from_multiline_string(
+        self, set_label: str, values: str
+    ) -> None:
+        """Special function to update a keywords set from a multi-line string."""
+        self.sets(set_label).update(
+            [n.strip().upper() for n in values.strip().split("\n")]
+        )
+
+    def copy_as(
+        self,
+        name: str,
+        formatted_name: Optional[str] = None,
+        docstring: Optional[str] = None,
+    ) -> "Dialect":
+        """Copy this dialect and create a new one with a different name.
+
+        This is the primary method for inheritance, after which, the
+        `replace` method can be used to override particular rules.
+        """
+        # Are we already expanded?
+        if self.expanded:  # pragma: no cover
+            # If we copy an already expanded dialect then any SegmentGenerators
+            # won't respond. This is most likely a mistake.
+            raise ValueError("Attempted to copy an already expanded dialect.")
+
+        # Copy sets if they are passed, so they can be mutated independently
+        new_sets = {}
+        for label in self._sets:
+            new_sets[label] = self._sets[label].copy()
+
+        assert self.lexer_matchers
+
+        return self.__class__(
+            name=name,
+            library=self._library.copy(),
+            lexer_matchers=self.lexer_matchers.copy(),
+            sets=new_sets,
+            inherits_from=self.name,
+            root_segment_name=self.root_segment_name,
+            # NOTE: We don't inherit the documentation fields.
+            formatted_name=formatted_name,
+            docstring=docstring,
+        )
+
+    def add(self, **kwargs: DialectElementType) -> None:
+        """Add a segment to the dialect directly.
+
+        This is the alternative to the decorator route, most useful for segments
+        defined using `make`. Segments are passed in as kwargs.
+
+        e.g.
+        dialect.add(SomeSegment=StringParser("blah", KeywordSegment))
+
+        Note that multiple segments can be added in the same call as this method
+        will iterate through the kwargs
+        """
+        for n in kwargs:
+            if n in self._library:  # pragma: no cover
+                raise ValueError(f"{n!r} is already registered in {self!r}")
+            self._library[n] = kwargs[n]
+
+    def replace(self, **kwargs: DialectElementType) -> None:
+        """Override a segment on the dialect directly.
+
+        Usage is very similar to add, but elements specified must already exist.
+        """
+        for n in kwargs:
+            if n not in self._library:  # pragma: no cover
+                raise ValueError(f"{n!r} is not already registered in {self!r}")
+            replacement = kwargs[n]
+            # If trying to replace with same, just skip.
+            if self._library[n] is replacement:
+                continue
+            # Check for replacement with a new but identical class.
+            # This would be a sign of redundant definitions in the dialect.
+            elif self._library[n] == replacement:
+                raise ValueError(
+                    f"Attempted unnecessary identical redefinition of {n!r} in {self!r}"
+                )  # pragma: no cover
+
+            # To replace a segment, the replacement must either be a
+            # subclass of the original, *or* it must have the same
+            # public methods and/or fields as it.
+            # NOTE: Other replacements aren't validated.
+            subclass = False
+            if isinstance(self._library[n], type) and not isinstance(
+                # NOTE: The exception here is we _are_ allowed to replace a
+                # segment with a `Nothing()` grammar, which shows that a segment
+                # has been disabled.
+                replacement,
+                Nothing,
+            ):
+                assert isinstance(
+                    replacement, type
+                ), f"Cannot replace {n!r} with {replacement}"
+                old_seg = cast(type["BaseSegment"], self._library[n])
+                new_seg = cast(type["BaseSegment"], replacement)
+                assert issubclass(old_seg, BaseSegment)
+                assert issubclass(new_seg, BaseSegment)
+                subclass = issubclass(new_seg, old_seg)
+                if not subclass:
+                    if old_seg.type != new_seg.type:
+                        raise ValueError(  # pragma: no cover
+                            f"Cannot replace {n!r} because 'type' property does not "
+                            f"match: {new_seg.type} != {old_seg.type}"
+                        )
+                    base_dir = set(dir(self._library[n]))
+                    cls_dir = set(dir(new_seg))
+                    missing = {
+                        n for n in base_dir.difference(cls_dir) if not n.startswith("_")
+                    }
+                    if missing:
+                        raise ValueError(  # pragma: no cover
+                            f"Cannot replace {n!r} because it's not a subclass and "
+                            f"is missing these from base: {', '.join(missing)}"
+                        )
+
+            self._library[n] = replacement
+
+    def add_update_segments(self, module_dct: dict[str, Any]) -> None:
+        """Scans module dictionary, adding or replacing segment definitions."""
+        for k, v in module_dct.items():
+            if isinstance(v, type) and issubclass(v, BaseSegment):
+                if k not in self._library:
+                    self.add(**{k: v})
+                else:
+                    non_seg_v = cast(Union[Matchable, SegmentGenerator], v)
+                    self.replace(**{k: non_seg_v})
+
+    def get_grammar(self, name: str) -> BaseGrammar:
+        """Allow access to grammars pre-expansion.
+
+        This is typically for dialect inheritance. This method
+        also validates that the result is a grammar.
+        """
+        if name not in self._library:  # pragma: no cover
+            raise ValueError(f"Element {name} not found in dialect.")
+        grammar = self._library[name]
+        if not isinstance(grammar, BaseGrammar):  # pragma: no cover
+            raise TypeError(
+                f"Attempted to fetch non grammar [{name}] with get_grammar."
+            )
+        return grammar
+
+    def get_segment(self, name: str) -> type["BaseSegment"]:
+        """Allow access to segments pre-expansion.
+
+        This is typically for dialect inheritance. This method
+        also validates that the result is a segment.
+        """
+        if name not in self._library:  # pragma: no cover
+            raise ValueError(f"Element {name} not found in dialect.")
+        segment = cast(type["BaseSegment"], self._library[name])
+
+        if issubclass(segment, BaseSegment):
+            return segment
+        else:  # pragma: no cover
+            raise TypeError(
+                f"Attempted to fetch non segment [{name}] "
+                f"with get_segment - type{type(segment)}"
+            )
+
+    def ref(self, name: str) -> Matchable:
+        """Return an object which acts as a late binding reference to the element named.
+
+        NB: This requires the dialect to be expanded, and only returns Matchables
+        as a result.
+
+        """
+        if not self.expanded:  # pragma: no cover
+            raise RuntimeError("Dialect must be expanded before use.")
+
+        if name in self._library:
+            res = self._library[name]
+            if res:
+                assert not isinstance(res, SegmentGenerator)
+                return res
+            else:  # pragma: no cover
+                raise ValueError(
+                    "Unexpected Null response while fetching {!r} from {}".format(
+                        name, self.name
+                    )
+                )
+        elif name.endswith("KeywordSegment"):  # pragma: no cover
+            keyword = name[0:-14]
+            keyword_tip = (
+                "\n\nThe syntax in the query is not (yet?) supported. Try to"
+                " narrow down your query to a minimal, reproducible case and"
+                " raise an issue on GitHub.\n\n"
+                "Or, even better, see this guide on how to help contribute"
+                " keyword and/or dialect updates:\n"
+                "https://docs.sqlfluff.com/en/stable/perma/contribute_dialect_keywords.html"  # noqa E501
+            )
+            # Keyword errors are common so avoid printing the whole, scary,
+            # traceback as not that useful and confusing to people.
+            sys.tracebacklimit = 0
+            raise RuntimeError(
+                "Grammar refers to the "
+                "{!r} keyword which was not found in the {} dialect.{}".format(
+                    keyword.upper(), self.name, keyword_tip
+                )
+            )
+        else:  # pragma: no cover
+            raise RuntimeError(
+                "Grammar refers to "
+                "{!r} which was not found in the {} dialect.".format(name, self.name)
+            )
+
+    def set_lexer_matchers(self, lexer_matchers: list[LexerType]) -> None:
+        """Set the lexer struct for the dialect.
+
+        This is what is used for base dialects. For derived dialects
+        (which don't exist yet) the assumption is that we'll introduce
+        some kind of *patch* function which could be used to mutate
+        an existing `lexer_matchers`.
+        """
+        self.lexer_matchers = lexer_matchers
+
+    def get_lexer_matchers(self) -> list[LexerType]:
+        """Fetch the lexer struct for this dialect."""
+        if self.lexer_matchers:
+            return self.lexer_matchers
+        else:  # pragma: no cover
+            raise ValueError(f"Lexing struct has not been set for dialect {self}")
+
+    def patch_lexer_matchers(self, lexer_patch: list[LexerType]) -> None:
+        """Patch an existing lexer struct.
+
+        Used to edit the lexer of a sub-dialect.
+        """
+        buff = []
+        if not self.lexer_matchers:  # pragma: no cover
+            raise ValueError("Lexer struct must be defined before it can be patched!")
+
+        # Make a new data struct for lookups
+        patch_dict = {elem.name: elem for elem in lexer_patch}
+
+        for elem in self.lexer_matchers:
+            if elem.name in patch_dict:
+                buff.append(patch_dict[elem.name])
+            else:
+                buff.append(elem)
+        # Overwrite with the buffer once we're done
+        self.lexer_matchers = buff
+
+    def insert_lexer_matchers(self, lexer_patch: list[LexerType], before: str) -> None:
+        """Insert new records into an existing lexer struct.
+
+        Used to edit the lexer of a sub-dialect. The patch is
+        inserted *before* whichever element is named in `before`.
+        """
+        buff = []
+        found = False
+        if not self.lexer_matchers:  # pragma: no cover
+            raise ValueError("Lexer struct must be defined before it can be patched!")
+
+        for elem in self.lexer_matchers:
+            if elem.name == before:
+                found = True
+                for patch in lexer_patch:
+                    buff.append(patch)
+                buff.append(elem)
+            else:
+                buff.append(elem)
+
+        if not found:  # pragma: no cover
+            raise ValueError(
+                f"Lexer struct insert before '{before}' failed because tag never found."
+            )
+        # Overwrite with the buffer once we're done
+        self.lexer_matchers = buff
+
+    def get_root_segment(self) -> Union[type[BaseSegment], Matchable]:
+        """Get the root segment of the dialect."""
+        return self.ref(self.root_segment_name)

--- a/src/sqlfluff/core/helpers/dict.py
+++ b/src/sqlfluff/core/helpers/dict.py
@@ -79,7 +79,7 @@ def nested_combine(*dicts: NestedStringDict[T]) -> NestedStringDict[T]:
 def dict_diff(
     left: NestedStringDict[T],
     right: NestedStringDict[T],
-    ignore: Optional[list[st] = None,
+    ignore: Optional[list[str]] = None,
 ) -> NestedStringDict[T]:
     """Work out the difference between two dictionaries.
 

--- a/src/sqlfluff/core/helpers/dict.py.bak
+++ b/src/sqlfluff/core/helpers/dict.py.bak
@@ -1,0 +1,294 @@
+"""Dict helpers, mostly used in config routines."""
+
+from collections.abc import Iterable, Iterator, Sequence
+from copy import deepcopy
+from typing import Optional, TypeVar, Union, cast
+
+T = TypeVar("T")
+
+NestedStringDict = dict[str, Union[T, "NestedStringDict[T]"]]
+"""Nested dict, with keys as strings.
+
+All values of the dict are either values of the given type variable T, or
+are themselves dicts with the same nested properties. Variables of this type
+are used regularly in configuration methods and classes.
+"""
+
+NestedDictRecord = tuple[tuple[str, ...], T]
+"""Tuple form record of a setting in a NestedStringDict.
+
+The tuple of strings in the first element is the "address" in the NestedStringDict
+with the value as the second element on the tuple.
+"""
+
+
+def nested_combine(*dicts: NestedStringDict[T]) -> NestedStringDict[T]:
+    """Combine an iterable of dictionaries.
+
+    Each dictionary is combined into a result dictionary. For
+    each key in the first dictionary, it will be overwritten
+    by any same-named key in any later dictionaries in the
+    iterable. If the element at that key is a dictionary, rather
+    than just overwriting we use the same function to combine
+    those dictionaries.
+
+    Args:
+        *dicts: An iterable of dictionaries to be combined.
+
+    Returns:
+        `dict`: A combined dictionary from the input dictionaries.
+
+    NOTE: This method has the added side effect of copying all
+    the dict objects within it. This effectively means that it
+    can provide a layer of isolation.
+
+    A simple example:
+    >>> nested_combine({"a": {"b": "c"}}, {"a": {"d": "e"}})
+    {'a': {'b': 'c', 'd': 'e'}}
+
+    Keys overwrite left to right:
+    >>> nested_combine({"a": {"b": "c"}}, {"a": {"b": "e"}})
+    {'a': {'b': 'e'}}
+    """
+    r: NestedStringDict[T] = {}
+    for d in dicts:
+        for k in d:
+            if k in r and isinstance(r[k], dict):
+                if isinstance(d[k], dict):
+                    # NOTE: The cast functions here are to appease mypy which doesn't
+                    # pick up on the `isinstance` calls above.
+                    r[k] = nested_combine(
+                        cast(NestedStringDict[T], r[k]), cast(NestedStringDict[T], d[k])
+                    )
+                else:  # pragma: no cover
+                    raise ValueError(
+                        "Key {!r} is a dict in one config but not another! PANIC: "
+                        "{!r}".format(k, d[k])
+                    )
+            else:
+                # In normal operation, these nested dicts should only contain
+                # immutable objects like strings, or contain lists or dicts
+                # which are simple to copy. We use deep copy to make sure that
+                # and dicts or lists within the value are also copied. This should
+                # also protect in future in case more exotic objects get added to
+                # the dict.
+                r[k] = deepcopy(d[k])
+    return r
+
+
+def dict_diff(
+    left: NestedStringDict[T],
+    right: NestedStringDict[T],
+    ignore: Optional[list[st] = None,
+) -> NestedStringDict[T]:
+    """Work out the difference between two dictionaries.
+
+    Returns a dictionary which represents elements in the `left`
+    dictionary which aren't in the `right` or are different to
+    those in the `right`. If the element is a dictionary, we
+    recursively look for differences in those dictionaries,
+    likewise only returning the differing elements.
+
+    NOTE: If an element is in the `right` but not in the `left`
+    at all (i.e. an element has been *removed*) then it will
+    not show up in the comparison.
+
+    Args:
+        left (:obj:`dict`): The object containing the *new* elements
+            which will be compared against the other.
+        right (:obj:`dict`): The object to compare against.
+        ignore (:obj:`list` of `str`, optional): Keys to ignore.
+
+    Returns:
+        `dict`: A dictionary representing the difference.
+
+    Basic functionality shown, especially returning the left as:
+    >>> dict_diff({"a": "b", "c": "d"}, {"a": "b", "c": "e"})
+    {'c': 'd'}
+
+    Ignoring works on a key basis:
+    >>> dict_diff({"a": "b"}, {"a": "c"})
+    {'a': 'b'}
+    >>> dict_diff({"a": "b"}, {"a": "c"}, ["a"])
+    {}
+    """
+    buff: NestedStringDict[T] = {}
+    for k in left:
+        if ignore and k in ignore:
+            continue
+        # Is the key there at all?
+        if k not in right:
+            buff[k] = left[k]
+        # Is the content the same?
+        elif left[k] == right[k]:
+            continue
+        # If it's not the same but both are dicts, then compare
+        elif isinstance(left[k], dict) and isinstance(right[k], dict):
+            diff = dict_diff(
+                cast(NestedStringDict[T], left[k]),
+                cast(NestedStringDict[T], right[k]),
+                ignore=ignore,
+            )
+            # Only include the difference if non-null.
+            if diff:
+                buff[k] = diff
+        # It's just different
+        else:
+            buff[k] = left[k]
+    return buff
+
+
+def records_to_nested_dict(
+    records: Iterable[NestedDictRecord[T]],
+) -> NestedStringDict[T]:
+    """Reconstruct records into a dict.
+
+    >>> records_to_nested_dict(
+    ...     [(("foo", "bar", "baz"), "a"), (("foo", "bar", "biz"), "b")]
+    ... )
+    {'foo': {'bar': {'baz': 'a', 'biz': 'b'}}}
+    """
+    result: NestedStringDict[T] = {}
+    for key, val in records:
+        ref: NestedStringDict[T] = result
+        for step in key[:-1]:
+            # If the subsection isn't there, make it.
+            if step not in ref:
+                ref[step] = {}
+            # Then step into it.
+            subsection = ref[step]
+            assert isinstance(subsection, dict)
+            ref = subsection
+        ref[key[-1]] = val
+    return result
+
+
+def iter_records_from_nested_dict(
+    nested_dict: NestedStringDict[T],
+) -> Iterator[NestedDictRecord[T]]:
+    """Walk a config dict and get config elements.
+
+    >>> list(
+    ...    iter_records_from_nested_dict(
+    ...        {"foo":{"bar":{"baz": "a", "biz": "b"}}}
+    ...    )
+    ... )
+    [(('foo', 'bar', 'baz'), 'a'), (('foo', 'bar', 'biz'), 'b')]
+    """
+    for key, val in nested_dict.items():
+        if isinstance(val, dict):
+            for partial_key, sub_val in iter_records_from_nested_dict(val):
+                yield (key,) + partial_key, sub_val
+        else:
+            yield (key,), val
+
+
+def nested_dict_get(
+    dict_obj: NestedStringDict[T], keys: Sequence[str], key_index: int = 0
+) -> Union[T, NestedStringDict[T]]:
+    """Perform a lookup in a nested dict object.
+
+    Lookups are performed by iterating keys.
+    >>> nested_dict_get(
+    ...     {"a": {"b": "c"}}, ("a", "b")
+    ... )
+    'c'
+
+    Lookups may return sections of nested dicts.
+    >>> nested_dict_get(
+    ...     {"a": {"b": "c"}}, ("a",)
+    ... )
+    {'b': 'c'}
+
+    Raises `KeyError` if any keys are not found.
+    >>> nested_dict_get(
+    ...     {"a": {"b": "c"}}, ("p", "q")
+    ... )
+    Traceback (most recent call last):
+        ...
+    KeyError: "'p' not found in nested dict lookup"
+
+    Raises `KeyError` we run out of dicts before keys are exhausted.
+    >>> nested_dict_get(
+    ...     {"a": {"b": "d"}}, ("a", "b", "c")
+    ... )
+    Traceback (most recent call last):
+        ...
+    KeyError: "'b' found non dict value, but there are more keys to iterate: ('c',)"
+
+    """
+    assert keys, "Nested dict lookup called without keys."
+    assert key_index < len(keys), "Key exhaustion on nested dict lookup"
+
+    next_key = keys[key_index]
+    if next_key not in dict_obj:
+        raise KeyError(f"{next_key!r} not found in nested dict lookup")
+    next_value = dict_obj[next_key]
+
+    # Are we all the way through the keys?
+    if key_index + 1 == len(keys):
+        # NOTE: Could be a section or a value.
+        return next_value
+
+    # If we're not all the way through the keys, go deeper if we can.
+    if not isinstance(next_value, dict):
+        raise KeyError(
+            f"{next_key!r} found non dict value, but there are more keys to "
+            f"iterate: {keys[key_index + 1 :]}"
+        )
+
+    return nested_dict_get(next_value, keys, key_index=key_index + 1)
+
+
+def nested_dict_set(
+    dict_obj: NestedStringDict[T],
+    keys: Sequence[str],
+    value: Union[T, NestedStringDict[T]],
+    key_index: int = 0,
+) -> None:
+    """Set a value in a nested dict object.
+
+    Lookups are performed by iterating keys.
+    >>> d = {"a": {"b": "c"}}
+    >>> nested_dict_set(d, ("a", "b"), "d")
+    >>> d
+    {'a': {'b': 'd'}}
+
+    Values may set dicts.
+    >>> d = {"a": {"b": "c"}}
+    >>> nested_dict_set(d, ("a", "b"), {"d": "e"})
+    >>> d
+    {'a': {'b': {'d': 'e'}}}
+
+    Any keys not found will be created.
+    >>> d = {"a": {"b": "c"}}
+    >>> nested_dict_set(d, ("p", "q"), "r")
+    >>> d
+    {'a': {'b': 'c'}, 'p': {'q': 'r'}}
+
+    Values may be overwritten with sub keys.
+    >>> d = {"a": {"b": "c"}}
+    >>> nested_dict_set(d, ("a", "b", "d"), "e")
+    >>> d
+    {'a': {'b': {'d': 'e'}}}
+    """
+    assert keys, "Nested dict lookup called without keys."
+    assert key_index < len(keys), "Key exhaustion on nested dict lookup"
+
+    next_key = keys[key_index]
+    # Create an empty dictionary if key not found.
+    if next_key not in dict_obj:
+        dict_obj[next_key] = {}
+    # Overwrite the value to a dict if the existing value isn't one.
+    elif not isinstance(dict_obj[next_key], dict):
+        dict_obj[next_key] = {}
+    next_value = dict_obj[next_key]
+    assert isinstance(next_value, dict)
+
+    # Do we have more keys to set?
+    # If we do, recurse:
+    if key_index + 1 < len(keys):
+        nested_dict_set(next_value, keys=keys, value=value, key_index=key_index + 1)
+    # If we don't, then just set the value:
+    else:
+        dict_obj[next_key] = value


### PR DESCRIPTION
This PR addresses the syntax errors causing the GitHub Actions workflow failures in the "mypy" and "mypyc" tests.

## Changes
- Added missing closing parenthesis in `sets()` method at line 112
- Added missing argument and closing parenthesis in `bracket_sets()` method at line 121

These syntax errors were causing the build to fail as they prevented the Python code from being parsed correctly.